### PR TITLE
Fix publish job permissions: use actions: read only

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
     steps:
       - name: Download distributions

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: read
-      contents: read
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,6 +85,8 @@ jobs:
     if: startsWith(github.event.ref, 'refs/tags') || github.event_name == 'release'
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Download distributions
         uses: actions/download-artifact@v6


### PR DESCRIPTION
CodeQL flagged the `publish` job for missing an explicit permissions block. The job never checks out the repo — it only downloads a build artifact and publishes to PyPI via API token secrets.

## Changes

- **`.github/workflows/publish.yml`**: Add job-level `permissions` to `publish` with only `actions: read` (required by `actions/download-artifact`); omit `contents: read` since no checkout occurs.

```yaml
publish:
  runs-on: ubuntu-latest
  permissions:
    actions: read   # needed for download-artifact; contents: read intentionally omitted
```